### PR TITLE
General Fixes & Formatting for Staff Training - 1st Pass

### DIFF
--- a/(5) Protocols/Staff Training.md
+++ b/(5) Protocols/Staff Training.md
@@ -1,155 +1,45 @@
-
-
 ##  Introduction
 
-This a rough collection of fixes, tips and tricks and routine jobs associated with being part of the Ultraseedbox Staff. Some may not apply depending on your role here, don’t worry this is just to give you the newcomer a point of reference when working. You are still encouraged to ask questions be inquisitive and learn as much as you can. This guide isn’t just for newcomers either we hope this is useful for everybody on staff. This guide does not have a set goal in mind as it does not aim to address one issue but merely serves as a record of all the fixes and tidbits we learn in a staffer’s role. We’ve done our best to categorize different information under Header and subheaders based on the information contained within. We hope you enjoy your stay with us and we welcome you wholeheartedly to the Ultraseedbox Family. Please note this guide is forever evolving if you would like to add to the guide with your Tidbit please feel free to do so but please make sure it is under a relevant header, If one does not exist please create one.
+This a rough collection of fixes, tips & tricks and routine jobs associated with being part of the Ultraseedbox Staff. Some may not apply depending on your role here — don’t worry this is just to give you the newcomer a point of reference when working. You are still encouraged to ask questions, be inquisitive and learn as much as you can.
 
+This guide does not aim to address one specific issue but merely serves as a record of all the fixes and tidbits we learn in a staffer’s role. We hope you enjoy your stay with us and we welcome you wholeheartedly to the Ultraseedbox Family. 
 
-## **Ticket Tidbits**
+*Please note this guide is forever evolving. If you would like to add to the guide with your tidbit, please feel free to do so but please make sure it is under a relevant header. If one does not exist please create one.*
 
-
-
+## Ticket Tidbits
 
 ### WHMCS Auto-refresh
 
-Whmcs has a useful auto-refresh feature which can help you keep on top of tickets for example if you go to `Support tab > Support tickets > Open` you will see a list of open tickets under the main tabs are two gray tabs marked `Search/Filter` and `auto-refresh`. Clicking auto-refresh will allow you to pick an interval then `Click Apply` this now sticks for every session so you can keep the page open and have it update the screen each minute
-
+WHMCS has a useful auto-refresh feature which can help you keep on top of tickets. For example: If you go to `Support tab > Support tickets > Open` you will see a list of open tickets. Under the main tabs are two gray tabs marked `Search/Filter` and `auto-refresh`. Clicking auto-refresh will allow you to pick an interval then `Click Apply`. This now sticks for every session so you can keep the page open and have it update the screen each minute.
 
 ### Transfers underway must be marked IN PROGRESS!
 
-“If you see things like slot info in a note, or "transfer" stuff like this, and you do reply to it. make sure to ` put it in "In Progress" state ` when you reply
+If you see things like slot info in a note, or "transfer" stuff like this, and you do reply to it, make sure to put it in "In Progress" state when you reply, otherwise clients will end up with 2 slots for free basically (because we keep track of the migrated slots this way to mark them for removal after client has verified their migrated data. The "In Progress" state is for when we will reply to them later (like working on the issue still, for example). If you're working on the ticket, just do "WIP" on a note - that's how other staff will know to leave it alone (vs doing an "in progress" state).
 
+### Guest Tickets
 
+Try to get a client to make a linked ticket, not a guest. You can't see the client's slot details via WHMCS. Solve issue or suggest resolution if possible with info available, but also include information and link on how to submit a “verified” logged-in ticket.
 
-otherwise, clients will end up with 2 slots for free basically (because we keep track of the migrated slots this way to mark them for removal after client has verified their migrated data)”
-
-
-
-the "In Progress" is just when we will reply to them later (like working on the issue still for example)
-
-
-
-`if you're working on the ticket, just do WIP` on a note, thats how other staff will know to leave it alone (vs doing an "in progress" state).
-
-
-
-
-### **Guest Tickets**
-
-
-
-Try to get a client to make a linked ticket, not a guest you can't see his slot details via WHMCS. Solve issue or suggest resolution if possible with info available, but also include information and link on how to submit a “verified” logged-in ticket.
-
-`You can tell this if slot information is missing from the bar above their reply`, send them this with your twist:
-
+You can tell this if slot information is missing from the bar above their reply, send them this with your twist:
 
 ```
- We are always happy to assist our customers but to provide the best experience possible it's recommended to open a support ticket from within the client area only.
-
-
+We are always happy to assist our customers but, to provide the best experience possible, it's recommended to open a support ticket from within the client area only.
 
 The client login page to submit a verified ticket is located at:
 
-
-
 > https://my.ultraseedbox.com/clientarea.php
 
-
-
 This helps us to verify your account and enables us to see your service details on our end to provide you with the best support possible.
-
-
 
 Please accept our apologies for any inconvenience this may cause.
 ```
 
+## General Tidbits
 
-
-
-
-## **Application Tidbits**
-
-
-
-
-### **(Ombi)**
-
-
-
-Assuming the Client wants the SSL/HTTPS url set (https://username.slotname.usbx.me/ombi)
-
-which requires that baseurl setting in their Ombi Settings
-
-
-If a user has already incorrectly set their baseurl you will need to fix it using MY SQL to edit the file required.  
-
-### **My SQL Base URL Edit**
-
-
-
-`app-ombi stop`
-
-
-
-Make backup of file to edit:
-
-`cp ~/.config/ombi/OmbiSettings.db ~/.config/ombi/OmbiSettings.db.bak`
-
-
-
-Download:
-
-` ~/.config/ombi/OmbiSettings.db `
-
-
-
-Open with "DB browser for SQLite" (a small app that should be available on Windows, Mac, and linux)
-
-
-```
-Browse Data (TAB)
-
-Tab: Global Settings (dropdown list)
-
-Select cell with {"BaseUrl":"/lw913.usbx.me:17696"
-
-
-
-Fix incorrect setting with: "edit Database Cell" section on right
-
-{"BaseUrl":"/servername.usbx.me:port"
-
-
-with correct baseurl setting:
-
-
-{"BaseUrl":"/ombi"
-
-Click Apply
-
-"DB browser for SQLite" File >> Write Changes
-```
-
-Upload fixed OmbiSettings.db overwriting ~/.config/ombi/OmbiSettings.db on client's slot
-
-`app-ombi restart`
-
-client's ombi should now be fixed and accessible from https://username.lw/###.usbx.me/ombi , and webui port method as well again.
-
-
-
-
-
-
-
-
-### **Reinstall app steps to possibly resolve an issue:**
-
-
-
-just a tip on app troubleshooting here:
+Just a tip on app troubleshooting here:
 
 UCP wasn't showing any version for rTorrent
+
 ```
 stop rTorrent
 backup rTorrent
@@ -157,11 +47,12 @@ uninstall rTorrent
 reinstall rTorrent
 restore rTorrent which now works (and usually does for a borked UCP app like this)
 ```
+
 `app-rtorrent stop`
 
 `mv ~/.config/rtorrent ~/.config/rtorrent.BAK`
 
-`IN UCP:` uninstall rtorrent, reinstall rtorrent
+In UCP: Uninstall rTorrent and then reinstall rTorrent
 
 `app-rtorrent stop`
 
@@ -171,20 +62,60 @@ restore rTorrent which now works (and usually does for a borked UCP app like thi
 
 `app-rtorrent restart`
 
+## Application Tidbits
 
+### Ombi
 
+If a client's Ombi installation is inaccessible due to an incorrectly set **Base URL**, then you will need to fix it by editing the database file itself.  
 
-### **RUTORRENT - The client cannot connect to rTorrent session via ruTorrent, but we can (Antivirus ? something local?)**
+#### Database Base URL Edit
 
+`app-ombi stop`
+
+Make backup of file to edit:
+
+`cp ~/.config/ombi/OmbiSettings.db ~/.config/ombi/OmbiSettings.db.bak`
+
+Download:
+
+` ~/.config/ombi/OmbiSettings.db `
+
+Open with (DB Browser for SQLite)[https://sqlitebrowser.org/] - a small app that should be available on Windows, Mac, and linux
+
+```
+Browse Data (TAB)
+
+Tab: Global Settings (dropdown list)
+
+Select cell with {"BaseUrl":"/lw913.usbx.me:17696"
+
+Fix incorrect setting with: "edit Database Cell" section on right
+
+{"BaseUrl":"/servername.usbx.me:port"
+
+with correct baseurl setting:
+
+{"BaseUrl":"/ombi"
+
+Click Apply
+
+"DB Browser for SQLite" File >> Write Changes
+```
+
+Upload fixed "OmbiSettings.db" overwriting `~/.config/ombi/OmbiSettings.db` on client's slot
+
+`app-ombi restart`
+
+The client's Ombi installation should now be fixed and accessible from `https://username.lw/###.usbx.me/ombi`
+
+### RUTORRENT
+
+The client cannot connect to rTorrent session via ruTorrent, but we can. 
 
 ```
 Your rutorrent webui is connecting to your rTorrent client from our end and listing your active torrents without any troubleshooting required, the issue seems to be local to yourself.
 
-
-
 Please try some of these troubleshooting steps to hopefully resolve your ruTorrent not loading for you locally:
-
-
 
     Perform a browser "hard refresh" on your ruTorrent WebUI page using the keyboard combination CONTROL + F5
 
@@ -194,56 +125,39 @@ Please try some of these troubleshooting steps to hopefully resolve your ruTorre
 
     Check that no locally installed security software is interfering with or blocking your ruTorrent WebUI access page.
 
-
 ```
 
 ## Plex
 
-non-direct/nonsec connection showing in plex
+Non-direct/nonsec connection showing in plex
 
- a reclaim will resolve the "non-direct/non-secure" connections
+A reclaim will generally resolve the "non-direct/non-secure" connections
 
-` app-plex claim -c {claim-code-here} `
-
+`app-plex claim -c {claim-code-here}`
 
 ## Bazarr
 
 If you happen to use HTTP Proxy when working with a clients slot it has been reported that certain plugins may cause a infinite number of refreshes to occur. This has so far been confirmed with Bazarr and  proxy switchyOmega Firefox Addon but may also affect other applications.
 
+## Migration steps Tidbits (For those given Migration Duties)
 
-## **Migration steps Tidbits (For those given Migration Duties)**
-
-```
 Please Refer to the below entries for the differences in type of upgrades that can occur
-
-```
 
 Login to the new assigned slot
 
-
-
 `migrate-user-data -e emailaliasnumber username oldslotname`
 
-
-```
 If you get an error message saying cannot accept email, You must contact iStan Who will likely ask you to contact Panda to Whitelist your staff email in our tools. ASK STAN FIRST
-```
 
 The tool will email when the transfer is started and when finished. Next inputs is old slot username and old service without the host.
-
-
 
 When it starts, connect to the screen with `screen -r transfer` and wait for the actual files to transfer for an accurate ETA.
 
 Then in this ticket SET STATUS TO IN-PROGRESS (IMPORTANT !!!!!) and insert predefined reply Upgrades and Migrations -> 4. Transfer started and fill the predefined info (hours)
 
+Once the initial transfer is completed, check the user hasn’t moved stuff from transfer using `ncdu -x --exclude=transfer` , `~/media` and `~/files` should be checked specifically, these folders could be populated by user applications so you will have to use best judgement here on if you think a user has moved data.
 
-
-Once the initial transfer is completed
-
-Check the user hasn’t moved stuff from transfer using `ncdu -x --exclude=transfer` , `~/media and ~/files` should be checked specifically, these folders could be populated by user applications so you will have to use best judgement here on if you think a user has moved data
-
-If they have then send them a ticket along these lines.
+If they have moved data, then send them a ticket along these lines:
 
 ```
 Hi,
@@ -254,11 +168,9 @@ We will allow 24 hours before the script will automatically run maintenance.
 
 Otherwise, we can run a final pass of data migration for any missing data.
 
-
 ```
 
-
-You would run second pass inside a screen with the -s switch added:
+You would run second pass inside a screen with the `-S` switch added:
 
 `screen -S 2ndpass`
 
@@ -267,10 +179,10 @@ You would run second pass inside a screen with the -s switch added:
 Then add note onto ticket “2ndpass running in screen `2ndpass` \
 (no email notification will be sent on 2nd pass completion)
 
-after the client replies confirming the data and verifying it, we send the predefined reply 7 "old slot deleted" and then post the original slot username@LW### to the #server-migration discord channel, which then Tier2 purges it for recycling
+After the client replies confirming the data and verifying it, we send the predefined reply 7 "old slot deleted" and then post the original slot username@LW### to the #server-migration discord channel, which then Tier2 purges it for recycling.
 
-
-## **Upgrade steps (Prorated)**
+## Upgrade steps
+### Pro-rated
 
 Confirm first with Article1. ` Upgrade - Hi [NAME], Your slot would be upgraded on a pro-rated basis, any amount already paid this term wi… `
 
@@ -299,7 +211,7 @@ Once the User has paid invoice and it is confirmed You can check Invoices tab in
 Await Client reply and proceed accordingly
 
 
-## **Upgrade steps (Free upgrades)**
+### Free Upgrades
 
 If a user is due an upgrade for free here are the steps.
 
@@ -320,9 +232,9 @@ Refresh your ticket to confirm pending and new product name
 also, when you reply, `use the stream upgrade(free) status`
 
 
-## **Upgrade steps (Dedicated Disks)**
+### Dedicated Disks
 
-Dedicated Disks allow for transfers without a bandwidth limit, All of the normal steps apply with a minor change to the transfer command during the 1st pass.
+Dedicated Disks allow for transfers without a bandwidth limit, all of the normal steps apply with a minor change to the transfer command during the 1st pass.
 
 `screen -S transfer`
 
@@ -344,10 +256,9 @@ You can then continue with the second pass as usual.
 60 and 60 are the: seconds then to hours conversion
 ```
 
-## **Mounting Tidbits**
+## Mounting Tidbits
 
-
-### **Space Issues**
+### Space Issues
 
 If a client is complaining about a loss of space while using rclone check their history of commands, `history` command will show you the SSH commands for the user its quite possible they are doing a Mount to Mount copy which fills up their ` ~/.cache` folder this can be verified by running ` ncdu -x ` which will show you the space hogs on the system after a scan.
 
@@ -363,28 +274,19 @@ You can see what a client is mounting by running the `mount | grep $USER ` never
 Sometimes, especially if a mount is using Mergerfs files can be placed inside the folder that a mount is normally placed on top of, This will stop the mount from being able to start. Find out the usual paths for a user mount then run `umount -l  /path/to/folder/ then  ls -a /path/to/folder/ `if the folders contain files move them elsewhere and perform a restart of the mount service (Refer to USB Docs) then place the files you moved back into the mount folder.
 
 
-## **Raffle instructions**
+## Raffle instructions
 
 This is for discord use and will likely be handled by a single member of staff during special occasions
 
 `.raffle start 24:00:00 ITEM HERE`
 
-
-
 It asks for Description. Add one.
-
-
 
 Then it asks how many winners. So add that. Bot only allows up to 9
 
-
-
 Then it'll ask for 2 questions. First one if you want to set how many days do they have to be here. I set it personally to 1 day.
 
-
-
 Then it'll ask if which Discord roles can join. Type in yes then when asked, type in Verified
-
 
 ## Useful commands
 
@@ -402,20 +304,20 @@ Custom Port and path copying to folder called transfer
 
 `rsync -aHAXxv --numeric-ids --info=progress2 --bwlimit=20000 -e "ssh -p portnumberhere" username@oldbhost:/path/to/files transfer`
 
-
 ## Control System/Backend
 
-
 ### Port Bind Errors
+
 ```
 {"result": false, "data": {"message": "/usr/bin/docker: Error response from daemon: driver failed programming external connectivity on endpoint btsync-rayray (1900751dcd33ccadc6bfb434131a89ffb98255a6cd71933d2242943fe1daea85): listen tcp 0.0.0.0:21120: bind: address already in use.\n"}}
 ```
+
 If a user is having issues installing a new application especially if this is a new client/slot, This could mean another user has accidentally been assigned that port number on one of their applications.
 
 However there are some steps that you can do
 
+### Via UCP
 
-### Via CP
 ```
 Install
 
@@ -425,6 +327,7 @@ Cleanup
 ```
 
 ### VIA SSH
+
 ```
 app-appname install
 
@@ -432,7 +335,5 @@ app-appname uninstall
 ````
 
 ### Contact Tier 1 Staff
-
-
 
 If none of these actions help your only option is to Contact a Tier 1 to run a ps aux | grep command and see if there are any port clashes


### PR DESCRIPTION
Got as far as `Upgrade Steps`. Will want to utilize lists for those sections rather than the current, weird inline code elements...

General Notes:
• Try to keep paragraph blocks under ~80 words
• Avoid adding formatting to Heading elements such as bold or italic
• We'll work on developing consistent formatting for inline declaration of things like application setting variables, filesystem paths, urls, section titles or "Step Paths". For example: 
    • "**Settings** -> **General** -> **Appearance**"
    • `~/media`
    • "Section Title"
    • **BaseUrl**